### PR TITLE
Behave semi-transparently on 304 if requester sets cache headers

### DIFF
--- a/examples/example-etag.js
+++ b/examples/example-etag.js
@@ -1,0 +1,43 @@
+/**
+ * Etag example
+ *
+ * Run with `node example-etag.js`. This example shows how fetching a resource
+ * and setting the If-None-Match request header returns a 304 when resource has
+ * not been modified.
+ */
+const fetch = require('../');
+
+fetch.setParameter('logToConsole', true);
+
+async function run() {
+  const etag = '"5421-55a8e11cc2280"';
+  console.log(`Fetch https://www.w3.org/TR/2012/REC-hr-time-20121217/ with etag ${etag}`);
+  let resp = await fetch('https://www.w3.org/TR/2012/REC-hr-time-20121217/', {
+    refresh: 'once', // Needed because of invalid cache semantics in W3C servers
+    compress: false,
+    headers: {
+      'If-None-Match': etag
+    }
+  });
+  console.log(`Received HTTP status ${resp.status} with etag ${resp.headers.get('etag')}`)
+
+  console.log();
+  console.log(`Put https://www.w3.org/TR/2012/REC-hr-time-20121217/ in file cache if needed`);
+  resp = await fetch('https://www.w3.org/TR/2012/REC-hr-time-20121217/', {
+    refresh: 'force',
+    compress: false,
+  });
+  console.log(`Received HTTP status ${resp.status} with etag ${resp.headers.get('etag')}`)
+
+  console.log();
+  console.log(`Fetch https://www.w3.org/TR/2012/REC-hr-time-20121217/ from file cache with etag ${etag}`);
+  resp = await fetch('https://www.w3.org/TR/2012/REC-hr-time-20121217/', {
+    refresh: 'never',
+    headers: {
+      'If-None-Match': etag
+    }
+  });
+  console.log(`Received HTTP status ${resp.status} with etag ${resp.headers.get('etag')}`)
+}
+
+run().catch(err => console.error(err));

--- a/examples/example-lastmodified.js
+++ b/examples/example-lastmodified.js
@@ -1,0 +1,41 @@
+/**
+ * Last-Modified example
+ *
+ * Run with `node example-lastmodified.js`. This example shows how fetching a
+ * resource and setting the If-Modified-Since request header returns a 304 when
+ * resource has not been modified.
+ */
+const fetch = require('../');
+
+fetch.setParameter('logToConsole', true);
+
+async function run() {
+  const lastModified = 'Mon, 02 Oct 2017 10:45:14 GMT';
+  console.log(`Fetch https://www.w3.org/TR/2012/REC-hr-time-20121217/ with last modified date ${lastModified}`);
+  let resp = await fetch('https://www.w3.org/TR/2012/REC-hr-time-20121217/', {
+    refresh: 'once',
+    headers: {
+      'If-Modified-Since': lastModified
+    }
+  });
+  console.log(`Received HTTP status ${resp.status} with last-modified header ${resp.headers.get('last-modified')}`)
+
+  console.log();
+  console.log(`Put https://www.w3.org/TR/2012/REC-hr-time-20121217/ in file cache if needed`);
+  resp = await fetch('https://www.w3.org/TR/2012/REC-hr-time-20121217/', {
+    refresh: 'force'
+  });
+  console.log(`Received HTTP status ${resp.status} with last-modified header ${resp.headers.get('last-modified')}`)
+
+  console.log();
+  console.log(`Fetch https://www.w3.org/TR/2012/REC-hr-time-20121217/ from file cache with last modified date ${lastModified}`);
+  resp = await fetch('https://www.w3.org/TR/2012/REC-hr-time-20121217/', {
+    refresh: 'never',
+    headers: {
+      'If-Modified-Since': lastModified
+    }
+  });
+  console.log(`Received HTTP status ${resp.status} with last-modified header ${resp.headers.get('last-modified')}`)
+}
+
+run().catch(err => console.error(err));


### PR DESCRIPTION
Take 2 of #6.

This updates the not-modified logic a bit to also return a 304 when the file cache contains the right response and no network request gets sent (e.g. because the `refresh` setting was set to `never`).

Handling of HTTP header names was also fixed to be case-insensitive.

This updates also introduces a couple of examples for If-None-Match and If-Modified-Since.

@dontcallmedom, for your review