### PR TITLE
Indicate in response headers when the cache was hit

### DIFF
--- a/fetch-filecache.js
+++ b/fetch-filecache.js
@@ -409,6 +409,9 @@ async function cacheFetch(url, options) {
       return new Response(null, { url, status: 304, headers });
     }
     let readable = fs.createReadStream(cacheFilename);
+    // Indicate this is coming from the cache via
+    // https://www.rfc-editor.org/rfc/rfc9211.html
+    headers["cache-status"] = "fetch-filecache-for-crawling; hit";
     return new Response(readable, { url, status, headers });
   }
 


### PR DESCRIPTION
Useful e.g. to adapt the rate-limiting behavior of a crawler